### PR TITLE
Support ITEM_MATCHING locator with multiple format substitutions

### DIFF
--- a/src/widgetastic_patternfly5/components/navigation.py
+++ b/src/widgetastic_patternfly5/components/navigation.py
@@ -97,7 +97,7 @@ class BaseNavigation:
         return [self.browser.text(el) for el in self.browser.elements(self.CURRENTLY_SELECTED)]
 
     @check_nav_loaded
-    def select(self, *levels: tuple[str], **kwargs):
+    def select(self, *levels, **kwargs):
         """Select an item in the navigation according to an ordered tuple of levels.
 
         :param *levels: Items to be clicked in the navigation; implied hierarchical structure

--- a/src/widgetastic_patternfly5/components/navigation.py
+++ b/src/widgetastic_patternfly5/components/navigation.py
@@ -116,7 +116,7 @@ class BaseNavigation:
                 import re
 
                 count = len([i.start() for i in re.finditer("{}", self.ITEM_MATCHING)])
-                subs = tuple([quote(level) for i in range(0, count)])
+                subs = [quote(level) for i in range(0, count)]
                 li = self.browser.element(self.ITEM_MATCHING.format(*subs), parent=current_item)
             except NoSuchElementException:
                 raise NavSelectionNotFound(

--- a/src/widgetastic_patternfly5/components/navigation.py
+++ b/src/widgetastic_patternfly5/components/navigation.py
@@ -117,7 +117,7 @@ class BaseNavigation:
 
                 count = len([i.start() for i in re.finditer("{}", self.ITEM_MATCHING)])
                 subs = tuple([quote(level) for i in range(0, count)])
-                li = self.browser.element(self.ITEM_MATCHING.format(*subs, parent=current_item))
+                li = self.browser.element(self.ITEM_MATCHING.format(*subs), parent=current_item)
             except NoSuchElementException:
                 raise NavSelectionNotFound(
                     f"{levels} not found in navigation tree. "


### PR DESCRIPTION
In tests that consume the `BaseNavigation.select` function, I need to support existing XPath locators missing OUIA attributes, but I also want to support newer elements that have the OUIA attributes. 

This means my ITEM_MATCHING would look like this:

```
class InsightsNavigation(Navigation):
    ITEMS = "./ul/li/*[self::a or self::button] | ./ul/section/ul/li/*[self::a or self::button]"
    # Match according to the old xpath OR on ouia component id for newer items that have them
    ITEM_MATCHING = ".//ul/li[.//*[self::a or self::button][normalize-space(.)={}]] | .//li[@data-ouia-component-id={}]"
```

Unfortunately the current implementation does not support this. 