### PR TITLE
Pin wt.core for OUIA partial component name support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 
 dependencies = [
-  "widgetastic.core>=1.0.5",
+  "widgetastic.core>=1.0.6",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
I miss this while reviewing #38 