### PR TITLE
Adjust locator for PF5 card

### DIFF
--- a/src/widgetastic_patternfly5/components/card.py
+++ b/src/widgetastic_patternfly5/components/card.py
@@ -35,7 +35,7 @@ class BaseCard:
 
 class Card(BaseCard, GenericLocatorWidget):
     DEFAULT_LOCATOR = (
-        ".//div[@data-ouia-component-type='PF5/Card'] | .//article[contains(@class, 'pf-c-card')]"
+        ".//div[@data-ouia-component-type='PF5/Card'] | .//article[contains(@class, '-c-card')]"
     )
 
     def __init__(self, parent, locator=None, logger=None):
@@ -47,7 +47,7 @@ class Card(BaseCard, GenericLocatorWidget):
 
 class CardForCardGroup(BaseCard, ParametrizedView):
     DEFAULT_LOCATOR = (
-        "(.//div[@data-ouia-component-type='PF5/Card'] | .//article[contains(@class, 'pf-c-card')])"
+        "(.//div[@data-ouia-component-type='PF5/Card'] | .//article[contains(@class, '-c-card')])"
     )
 
     def __init__(self, parent, locator=None, logger=None, **kwargs):


### PR DESCRIPTION
The class is pf-v5-c-card in PF5. 
![image](https://github.com/RedHatQE/widgetastic.patternfly5/assets/20647751/09df717b-0c86-4777-93f3-773666124863)

I suggest we update the locator to work.

Example of actual code from the support portal that DOES NOT work with the current locator:
![image](https://github.com/RedHatQE/widgetastic.patternfly5/assets/20647751/e9707987-c291-45c6-b269-51b6a1cdbbd3)
