### PR TITLE
Make pagination backward compatible

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,7 @@ jobs:
     name: 🐍 Tests (python-${{ matrix.python-version }}, ${{ matrix.browser }})
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         browser: [chrome, firefox]
         python-version: ["3.8", "3.9", "3.10"]

--- a/src/widgetastic_patternfly5/components/menus/dropdown.py
+++ b/src/widgetastic_patternfly5/components/menus/dropdown.py
@@ -65,9 +65,11 @@ class BaseDropdown:
     @property
     def is_open(self):
         """Returns True if the Dropdown is open"""
-        return "pf-m-expanded" in self.browser.classes(
-            self.BUTTON_LOCATOR
-        ) or "pf-m-expanded" in self.browser.classes(self)
+        return (
+            "pf-m-expanded" in self.browser.classes(self.BUTTON_LOCATOR)
+            or "pf-m-expanded" in self.browser.classes(self)
+            or self.browser.attributes(self.BUTTON_LOCATOR).get("aria-expanded") == "true"
+        )
 
     def open(self):
         """Opens a dropdown."""

--- a/src/widgetastic_patternfly5/components/menus/options_menu.py
+++ b/src/widgetastic_patternfly5/components/menus/options_menu.py
@@ -16,9 +16,10 @@ class BaseOptionsMenu:
     TEXT_LOCATOR = (
         './/div[contains(@class, "-c-options-menu") and child::button[normalize-space(.)={}]]'
     )
+    # PF4/5 backward compatibility locator
     DEFAULT_LOCATOR = (
-        "(.//button[contains(@class, '-c-menu-toggle') or "
-        "contains(@class, '-c-options-menu')]/parent::div)[1]"
+        ".//div[contains(@data-ouia-component-type, 'PaginationOptionsMenu')] | "
+        "(.//button[contains(@class, '-c-menu-toggle') or contains(@class, '-c-options-menu')]/parent::div)[1]"  # noqa
     )
 
     SELECTED_ITEMS_LOCATOR = (


### PR DESCRIPTION
Found out that some compliance tests are failing due to PF5 usage (we are not migrated to PF5 yet but I have already started using it). With making locators more generic tests are green (PF5 should work as normal)