### PR TITLE
Select: add support for typeahead select

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ itteration of [widgetastic.patternfly4](https://github.com/RedHatQE/widgetastic.
   - [menu-toggle](https://www.patternfly.org/components/menus/menu-toggle)
   - [options-menu](https://www.patternfly.org/components/menus/options-menu/)
   - [select](https://www.patternfly.org/components/menus/select)
+  - [typeahedselect](https://www.patternfly.org/components/menus/select/#typeahead)
 - [modal](https://www.patternfly.org/components/modal)
 - [navigation](https://www.patternfly.org/components/navigation)
 - [pagination](https://www.patternfly.org/components/pagination/)

--- a/src/widgetastic_patternfly5/components/menus/select.py
+++ b/src/widgetastic_patternfly5/components/menus/select.py
@@ -1,4 +1,5 @@
 from widgetastic.exceptions import NoSuchElementException
+from widgetastic.widget import TextInput
 
 from .dropdown import Dropdown
 from .dropdown import DropdownItemDisabled
@@ -181,4 +182,20 @@ class BaseCheckboxSelect(BaseSelect):
 
 
 class CheckboxSelect(BaseCheckboxSelect, Dropdown):
+    DEFAULT_LOCATOR = './/div[contains(@class, "-c-select")][1]'
+
+
+class BaseTypeaheadSelect(BaseSelect):
+    BUTTON_LOCATOR = (
+        ".//button[(contains(@class, '-c-select__toggle') "
+        "or contains(@class, '-c-menu-toggle')) "
+        "and not(contains(@class, '-c-select__toggle-clear'))]"
+    )
+    input = TextInput(locator=".//input")
+
+    def read(self):
+        return self.browser.get_attribute("value", self.input)
+
+
+class TypeaheadSelect(BaseTypeaheadSelect, Dropdown):
     DEFAULT_LOCATOR = './/div[contains(@class, "-c-select")][1]'

--- a/src/widgetastic_patternfly5/ouia.py
+++ b/src/widgetastic_patternfly5/ouia.py
@@ -15,6 +15,7 @@ from widgetastic_patternfly5.components.menus.dropdown import BaseDropdown
 from widgetastic_patternfly5.components.menus.menu import BaseCheckboxMenu
 from widgetastic_patternfly5.components.menus.menu import BaseMenu
 from widgetastic_patternfly5.components.menus.select import BaseSelect
+from widgetastic_patternfly5.components.menus.select import BaseTypeaheadSelect
 from widgetastic_patternfly5.components.modal import BaseModal
 from widgetastic_patternfly5.components.navigation import BaseNavigation
 from widgetastic_patternfly5.components.pagination import BaseCompactPagination
@@ -126,6 +127,10 @@ class Dropdown(BaseDropdown, OUIAGenericWidget):
 
 
 class Select(BaseSelect, Dropdown):
+    OUIA_COMPONENT_TYPE = "Select"
+
+
+class TypeaheadSelect(BaseTypeaheadSelect, Dropdown):
     OUIA_COMPONENT_TYPE = "Select"
 
 

--- a/testing/components/menus/test_select.py
+++ b/testing/components/menus/test_select.py
@@ -4,6 +4,7 @@ from widgetastic.widget import View
 from widgetastic_patternfly5 import CheckboxSelect
 from widgetastic_patternfly5 import Select
 from widgetastic_patternfly5 import SelectItemNotFound
+from widgetastic_patternfly5.components.menus.select import TypeaheadSelect
 
 TESTING_PAGE_URL = "https://patternfly-react-main.surge.sh/components/menus/select"
 
@@ -83,3 +84,51 @@ def test_checkbox_select_item_checkbox_select(checkbox_select):
     with pytest.raises(SelectItemNotFound):
         checkbox_select.fill({"Non existing item": True})
     assert not checkbox_select.is_open
+
+
+@pytest.fixture
+def typeahead_select(browser):
+    class TestView(View):
+        typeahead_select = TypeaheadSelect(locator=".//div[@id='ws-react-c-select-typeahead']")
+
+    return TestView(browser).typeahead_select
+
+
+def test_typeahead_select_is_displayed(typeahead_select):
+    assert typeahead_select.is_displayed
+
+
+def test_typeahead_select_items(typeahead_select):
+    assert set(typeahead_select.items) == {
+        "Alabama",
+        "Florida",
+        "New Jersey",
+        "New Mexico",
+        "New York",
+        "North Carolina",
+    }
+    assert typeahead_select.has_item("Alabama")
+    assert not typeahead_select.has_item("Non existing item")
+    assert typeahead_select.item_enabled("Alabama")
+
+
+def test_typeahead_select_open(typeahead_select):
+    assert not typeahead_select.is_open
+    typeahead_select.open()
+    assert typeahead_select.is_open
+    typeahead_select.close()
+    assert not typeahead_select.is_open
+
+
+def test_typeahead_select_item_select(typeahead_select):
+    typeahead_select.fill("New Mexico")
+    assert typeahead_select.read() == "New Mexico"
+    assert not typeahead_select.is_open
+    # try again to verify it works when an item was selected previously (or in
+    # case there is a default value)
+    typeahead_select.fill("Florida")
+    assert typeahead_select.read() == "Florida"
+    assert not typeahead_select.is_open
+    with pytest.raises(SelectItemNotFound):
+        typeahead_select.fill("Non existing item")
+    assert not typeahead_select.is_open


### PR DESCRIPTION
When there is an item selected it would click on the clear button instead of the toggle button when trying to access items or calling open(), this fixes that.