### PR TITLE
Update CHIP_ROOT to exclude groups

### DIFF
--- a/src/widgetastic_patternfly5/components/chip.py
+++ b/src/widgetastic_patternfly5/components/chip.py
@@ -14,7 +14,10 @@ class ChipReadOnlyError(Exception):
         self.chip = chip
 
 
-CHIP_ROOT = ".//div[contains(@class, '-c-chip') and not(contains(@class, '-m-overflow'))]"
+CHIP_ROOT = (
+    ".//div[contains(@class, '-c-chip') and not(contains(@class, '-m-overflow')) "
+    "and not(contains(@class, '-c-chip-group'))]"
+)
 CHIP_TEXT = ".//span[contains(@class, '-c-chip__text')]"
 CHIP_BADGE = ".//span[contains(@class, '-c-badge')]"
 GROUP_ROOT = ".//div[contains(@class, '-c-chip-group__main')]"

--- a/testing/components/test_chip.py
+++ b/testing/components/test_chip.py
@@ -63,6 +63,9 @@ def test_chipgroup_category(category_chip_group_view):
     assert category_chip_group_view.category_one.is_displayed
     assert category_chip_group_view.category_one.label == "Category one"
 
+    chips = ["Chip one", "Chip two", "Chip three"]
+    assert category_chip_group_view.category_one.read() == chips
+
     category_chip_group_view.category_one.close()
     assert not category_chip_group_view.category_one.is_displayed
 


### PR DESCRIPTION
When a Chip Group is created and a chip within it referenced, it does not resolve correctly, as there are 2 matches, the chip and the first component within the group (with class of the form "-c-chip-group__main").

Jira: [IQE-2718](https://issues.redhat.com/browse/IQE-2718)