### PR TITLE
Set locator for chip groups to point to the same element in the tree

### DIFF
--- a/src/widgetastic_patternfly5/components/chip.py
+++ b/src/widgetastic_patternfly5/components/chip.py
@@ -20,9 +20,10 @@ CHIP_ROOT = (
 )
 CHIP_TEXT = ".//span[contains(@class, '-c-chip__text')]"
 CHIP_BADGE = ".//span[contains(@class, '-c-badge')]"
-GROUP_ROOT = ".//div[contains(@class, '-c-chip-group__main')]"
+GROUP_ROOT = ".//div[contains(@class, '-c-chip-group') and @role='group']"
 CATEGORY_GROUP_ROOT = (
-    ".//div[contains(@class, '-c-chip-group') and contains(@class, 'pf-m-category')]"
+    ".//div[contains(@class, '-c-chip-group') and @role='group' "
+    "and contains(@class, 'pf-m-category')]"
 )
 CATEGORY_LABEL = ".//span[contains(@class, '-c-chip-group__label')]"
 CATEGORY_CLOSE = ".//div[contains(@class, '-c-chip-group__close')]/button"


### PR DESCRIPTION
Category and simple groups where pointing to different elements in the tree. This change makes both consistent.

Jira: [IQE-2717](https://issues.redhat.com/browse/IQE-2717)