### PR TITLE
Add Expandable section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ itteration of [widgetastic.patternfly4](https://github.com/RedHatQE/widgetastic.
 - [description-list](https://www.patternfly.org/components/description-list)
 - [drawer](https://www.patternfly.org/components/drawer)
 - [dual-list-selector](https://www.patternfly.org/components/dual-list-selector)
+- [expandable-section](https://www.patternfly.org/components/expandable-section)
 - forms
   - [form-select](https://www.patternfly.org/components/forms/form-select)
   - [radio](https://www.patternfly.org/components/forms/radio)

--- a/src/widgetastic_patternfly5/__init__.py
+++ b/src/widgetastic_patternfly5/__init__.py
@@ -25,6 +25,7 @@ from .components.description_list import DescriptionList
 from .components.drawer import Drawer
 from .components.dual_list_selector import DualListSelector
 from .components.dual_list_selector import SearchDualListSelector
+from .components.expandable_section import ExpandableSection
 from .components.forms.form_select import FormSelect
 from .components.forms.form_select import FormSelectDisabled
 from .components.forms.form_select import FormSelectOptionDisabled
@@ -137,4 +138,5 @@ __all__ = [
     "SwitchDisabled",
     "Tab",
     "Title",
+    "ExpandableSection",
 ]

--- a/src/widgetastic_patternfly5/components/expandable_section.py
+++ b/src/widgetastic_patternfly5/components/expandable_section.py
@@ -1,0 +1,60 @@
+from wait_for import wait_for_decorator
+from widgetastic.widget import View
+
+
+class ExpandableSection(View):
+    """Represents the Patternfly Expandable section widget.
+
+    Expands itself automatically when any child widget gets accessed, ensuring
+    that the widget is visible.
+
+    https://www.patternfly.org/components/expandable-section
+
+    NOTE: When using this in your code you need to set the ROOT yourself!
+
+    Example code with a button underneath the section:
+
+        class MySection(ExpandableSection):
+            ROOT = ".//div[contains(@data-testid, 'my-expandable-section')]"
+            my-button = Button(locator=".//button")
+
+    After creating the view you can run `MySection.my-button.click()` and it
+    will automatically expand and click on your button.
+    """
+
+    ROOT = './/div[contains(@class, "-c-expandable-section")]'
+    BUTTON_LOCATOR = ".//button"
+
+    @property
+    def is_expanded(self):
+        """Returns a boolean."""
+        if self.browser.get_attribute("aria-expanded", self.BUTTON_LOCATOR) == "true":
+            return True
+        else:
+            return False
+
+    def click(self):
+        """Clicks the expandable section button."""
+        return self.browser.click(self.BUTTON_LOCATOR)
+
+    def expand(self):
+        """Expands the section (checks if not expanded already first)."""
+        if not self.is_expanded:
+
+            @wait_for_decorator(timeout=3)
+            def _click():
+                self.click()
+                return self.is_expanded
+
+    def collapse(self):
+        """Collapses the section (checks if expanded already first)."""
+        if self.is_expanded:
+
+            @wait_for_decorator(timeout=3)
+            def _click():
+                self.click()
+                return not self.is_expanded
+
+    def child_widget_accessed(self, widget):
+        # Expand the section
+        self.expand()

--- a/testing/components/test_expandable_section.py
+++ b/testing/components/test_expandable_section.py
@@ -1,0 +1,28 @@
+from widgetastic.widget import Text
+from widgetastic.widget import View
+
+from widgetastic_patternfly5 import ExpandableSection
+
+TESTING_PAGE_URL = "https://patternfly-react-main.surge.sh/components/expandable-section"
+
+
+class SectionView(View):
+    @View.nested
+    class basic(ExpandableSection):
+        text = Text(".//div[contains(@class, '-c-expandable-section__content')]")
+
+
+def test_section_expansion(browser):
+    view = SectionView(browser)
+    view.basic.expand()
+    assert view.basic.is_expanded
+    view.basic.collapse()
+    assert not view.basic.is_expanded
+
+
+def test_section_text(browser):
+    view = SectionView(browser)
+    assert view.basic.is_displayed
+    assert view.basic.text.is_displayed
+    assert view.basic.text.read() == "This content is visible only when the component is expanded."
+    view.basic.collapse()


### PR DESCRIPTION
Adding this mainly because of the `child_widget_access` functionality. The widget is fairly simple, I was heavily inspired by the `tabs`  widget. 

Adding just a basic test as all the other sections work the same on the page and the text is visible anyway even without expanding. I have a better use case in iqe-image-builder plugin where I need to expand the section to access a button which is actually not clickable before. It works there for me as expected and even watching the test here it does expand the section before trying to read it.

I am not adding a `section_name` property for it as it can change based on whether it's expanded or not so I don't think it's very useful unlike the `tab_name` in the `tabs` widget...