### PR TITLE
Update gh-action-pypi-publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Test package
         run: twine check dist/*
       - name: Deploy to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.10
+        uses: pypa/gh-action-pypi-publish@v1.8.14
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
The metadata update for 2.3 causes pypi to reject the upload on current version.

Updated action _should_ pick up various updates for new metadata formats.