### PR TITLE
Remove reference to nonexistent attribute `enabled_items` in BaseSelect.item_select

### DIFF
--- a/src/widgetastic_patternfly5/components/menus/select.py
+++ b/src/widgetastic_patternfly5/components/menus/select.py
@@ -57,12 +57,7 @@ class BaseSelect:
         try:
             return super().item_select(item)
         except DropdownItemDisabled:
-            raise SelectItemDisabled(
-                'Item "{}" of {} is disabled\n'
-                "The following items are available and enabled: {}".format(
-                    item, repr(self), self.enabled_items
-                )
-            )
+            raise SelectItemDisabled('Item "{}" of {} is disabled')
 
     def fill(self, value):
         """Fills a Select with a value."""


### PR DESCRIPTION
`BaseSelect.item_select()` rewrites `DropdownItemDisabled` exception into `SelectItemDisabled`. The intent is to not only tell that requested item is disabled, but also to helpfully tell what items are enabled. To do that, `enabled_items` attribute is used.

However, that attribute was never implemented. There is no trace of it in git history.

As a result, when you try to select a disabled item, instead of raising a new exception with more useful message, a completely different exception is raised:

```
AttributeError: 'Select' object has no attribute 'enabled_items'
```

I found that very similar code existed in widgetastic.patternfly4. The `enabled_items` was removed in https://github.com/RedHatQE/widgetastic.patternfly4/pull/54 . That PR introduced CheckboxSelect and changed inheritance hierarchy. It _seems_ that `enabled_items` was supposed to be moved to another class, but somehow was missed.

Unfortunately, simply pasting back `enabled_items` definition is not an option. It calls `item_enabled`, which right now is implemented only for `BaseDropdown`. My limited testing shows it seems to effectively use `ITEM_LOCATOR` as it is defined in Dropdown, not Select, which results in inability to select the item from list. That raises even more confusing exception, which claims that item can't be found and then continues to say that exact item is available:

```
widgetastic_patternfly5.components.menus.select.SelectItemNotFound: Item 'Foo' not found in Select("locator"). Available items: ['Foo', 'Bar']
```

This PR removes the reference to nonexistent attribute. The message is maybe a bit less helpful than intended, but at least it provides the right idea what is wrong.