### PR TITLE
Fix for disabled dropdown with new tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ pip install -U pip setuptools wheel
 
 # install the package in editable mode
 pip install -e .[dev]
+# if you use zsh, pip install will fail. Use this instead:
+pip install -e ."[dev]"
+
 pre-commit install
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ pip install -U pip setuptools wheel
 # install the package in editable mode
 pip install -e .[dev]
 # if you use zsh, pip install will fail. Use this instead:
-pip install -e ."[dev]"
+pip install -e ".[dev]"
 
 pre-commit install
 ```

--- a/src/widgetastic_patternfly5/components/menus/dropdown.py
+++ b/src/widgetastic_patternfly5/components/menus/dropdown.py
@@ -58,7 +58,7 @@ class BaseDropdown:
     def is_enabled(self):
         """Returns if the dropdown itself is enabled and therefore interactive."""
         btn_classes = self.browser.classes(self.BUTTON_LOCATOR)
-        return "disabled" not in btn_classes or "pf-m-disabled" not in btn_classes
+        return "disabled" not in btn_classes and "pf-m-disabled" not in btn_classes
 
     def _verify_enabled(self):
         if not self.is_enabled:

--- a/testing/components/menus/test_dropdown_disabled.py
+++ b/testing/components/menus/test_dropdown_disabled.py
@@ -1,0 +1,66 @@
+import pytest
+from widgetastic.widget import Checkbox, View
+
+from widgetastic_patternfly5 import (
+    Dropdown,
+    DropdownDisabled,
+)
+
+TESTING_PAGE_COMPONENT = "components/menus/dropdown/react-templates/simple"
+
+
+@pytest.fixture
+def view(browser):
+    class TestView(View):
+        ROOT = ".//div[@id='ws-react-templates-c-dropdown-simple']/parent::div"
+        dropdown_custom_locator = Dropdown(
+            locator=".//button[contains(@data-ouia-component-type, '/MenuToggle') and contains(@data-ouia-component-id, 'default-1')]/parent::div"
+        )
+        disable_checkbox = Checkbox(locator=".//input[@id='simple-example-disabled-toggle']")
+
+    view = TestView(browser)
+    view.wait_displayed("10s")
+    return view
+
+
+@pytest.fixture
+def dropdown(view):
+    return getattr(view, "dropdown_custom_locator")
+
+
+def test_dropdown_is_displayed(dropdown):
+    assert dropdown.is_displayed
+
+
+def test_enabled_dropdown(view, dropdown):
+    view.disable_checkbox.fill(False)
+    assert dropdown.is_enabled
+
+
+def test_disabled_dropdown(view, dropdown):
+    view.disable_checkbox.fill(True)
+    assert not dropdown.is_enabled
+
+
+def test_disabled_dropdown_items(view, dropdown):
+    view.disable_checkbox.fill(True)
+    with pytest.raises(DropdownDisabled):
+        assert dropdown.items == [
+            "Action",
+            "Link",
+            "Disabled Action",
+            "",
+            "Second Action",
+        ]
+
+
+def test_disabled_dropdown_open(view, dropdown):
+    view.disable_checkbox.fill(True)
+    with pytest.raises(DropdownDisabled):
+        dropdown.open()
+
+
+def test_disabled_dropdown_item_select(view, dropdown):
+    view.disable_checkbox.fill(True)
+    with pytest.raises(DropdownDisabled):
+        dropdown.item_select("Action")

--- a/testing/components/menus/test_dropdown_disabled.py
+++ b/testing/components/menus/test_dropdown_disabled.py
@@ -12,11 +12,10 @@ TESTING_PAGE_COMPONENT = "components/menus/dropdown/react-templates/simple"
 @pytest.fixture
 def view(browser):
     class TestView(View):
-        ROOT = ".//div[@id='ws-react-templates-c-dropdown-simple']/parent::div"
         dropdown_custom_locator = Dropdown(
             locator=".//button[contains(@data-ouia-component-type, '/MenuToggle') and contains(@data-ouia-component-id, 'default-1')]/parent::div"
         )
-        disable_checkbox = Checkbox(locator=".//input[@id='simple-example-disabled-toggle']")
+        disable_checkbox = Checkbox(id="simple-example-disabled-toggle")
 
     view = TestView(browser)
     view.wait_displayed("10s")


### PR DESCRIPTION
`is_enabled` was returning `True` even for a disabled dropdown, because an OR operation was used instead of an AND.

Discovered with iqe-curiosity-plugin, IQE shell reproduce steps:
```
In [2]: view = navigate_to(app.curiosity, "AdvancedClusterManagement")
In [32]: btn_classes = view.filter_value.browser.classes(".//button[contains(@class, '-c-menu-toggle') or contains(@class, '-c-dropdown__toggle')]")

In [33]: btn_classes
Out[33]: {'curiosity-select-pf__toggle', 'pf-m-disabled', 'pf-v5-c-menu-toggle'}

In [34]: "disabled" not in btn_classes or "pf-m-disabled" not in btn_classes
Out[34]: True

In [35]: "disabled" not in btn_classes and "pf-m-disabled" not in btn_classes
Out[35]: False
```