### PR TITLE
Add create_item support to TypeaheadSelect fill method

### DIFF
--- a/src/widgetastic_patternfly5/components/menus/select.py
+++ b/src/widgetastic_patternfly5/components/menus/select.py
@@ -191,15 +191,40 @@ class CheckboxSelect(BaseCheckboxSelect, Dropdown):
 
 
 class BaseTypeaheadSelect(BaseSelect):
+    """Represents the Patternfly Typeahead Select.
+
+    https://www.patternfly.org/components/menus/select/#typeahead
+    """
+
     BUTTON_LOCATOR = (
         ".//button[(contains(@class, '-c-select__toggle') "
         "or contains(@class, '-c-menu-toggle')) "
         "and not(contains(@class, '-c-select__toggle-clear'))]"
     )
+    CREATE_ITEM_LOCATOR = ".//button[@id='select-typeahead-create']"
     input = TextInput(locator=".//input")
 
     def read(self):
         return self.browser.get_attribute("value", self.input)
+
+    def fill(self, value, create_item=False):
+        """Fills a TypeaheadSelect with a value.
+
+        Args:
+            value: The value to fill in or select.
+            create_item: If True, types the value and clicks the 'Create' option
+                         when the item is not found in the existing options.
+        """
+        if self.read() == value:
+            return False
+
+        if create_item and value not in self.items:
+            self.input.fill(value)
+            self.root_browser.click(self.CREATE_ITEM_LOCATOR)
+            return True
+        else:
+            self.item_select(value)
+            return True
 
 
 class TypeaheadSelect(BaseTypeaheadSelect, Dropdown):

--- a/testing/components/menus/test_select.py
+++ b/testing/components/menus/test_select.py
@@ -13,6 +13,9 @@ def view(browser):
         select = Select(locator=".//div[@id='ws-react-c-select-single-select']")
         checkbox_select = CheckboxSelect(locator='.//div[@id="ws-react-c-select-checkbox-select"]')
         typeahead_select = TypeaheadSelect(locator=".//div[@id='ws-react-c-select-typeahead']")
+        typeahead_create_select = TypeaheadSelect(
+            locator=".//div[@id='ws-react-c-select-typeahead-with-create-option']"
+        )
 
     yield TestView(browser)
 
@@ -159,3 +162,34 @@ def test_typeahead_select_item_select(typeahead_select):
     with pytest.raises(SelectItemNotFound):
         typeahead_select.fill("Non existing item")
     assert not typeahead_select.is_open
+
+
+@pytest.fixture
+def typeahead_create_select(view):
+    yield view.typeahead_create_select
+
+
+def test_typeahead_create_select_new_item(typeahead_create_select):
+    """Test TypeaheadSelect with create_item option for creating new items."""
+    assert typeahead_create_select.is_displayed
+
+    # Selecting an existing item should work normally
+    typeahead_create_select.fill("Alabama")
+    assert typeahead_create_select.read() == "Alabama"
+    assert not typeahead_create_select.is_open
+
+    # Same value should report no change
+    assert typeahead_create_select.fill("Alabama") is False
+
+    # Non-existing value without create_item should raise
+    with pytest.raises(SelectItemNotFound):
+        typeahead_create_select.fill("NonExistentItem")
+
+    # create_item=True with an existing item should select it normally
+    assert typeahead_create_select.fill("Florida", create_item=True) is True
+    assert typeahead_create_select.read() == "Florida"
+
+    # create_item=True with a new value should create and select it
+    assert typeahead_create_select.fill("MyNewOption", create_item=True) is True
+    assert typeahead_create_select.read() == "MyNewOption"
+    assert not typeahead_create_select.is_open


### PR DESCRIPTION
## Summary by Sourcery

Add support for creating new options via the TypeaheadSelect fill method and cover it with tests.

New Features:
- Allow BaseTypeaheadSelect.fill to optionally create and select a new item when it does not exist in the current options.

Tests:
- Add tests for TypeaheadSelect with create_item behavior, covering existing item selection, unchanged values, error paths, and creation of new options.