### PR TITLE
Use timeout instead of num_sec

### DIFF
--- a/src/widgetastic_patternfly5/components/chip.py
+++ b/src/widgetastic_patternfly5/components/chip.py
@@ -104,7 +104,7 @@ class Chip(ParametrizedView, _BaseChip):
 
         if not self.read_only:
             self.button.click()
-            wait_for(_gone, num_sec=3, message="wait for chip to dissappear", delay=0.1)
+            wait_for(_gone, timeout=3, message="wait for chip to disappear", delay=0.1)
         else:
             raise ChipReadOnlyError(self, "Chip is read-only")
 
@@ -133,7 +133,7 @@ class OverflowChip(_BaseChip):
             self._text.click()
         wait_for(
             func=self._show_less_shown,
-            num_sec=3,
+            timeout=3,
             delay=0.1,
             message="wait for 'show less' button to appear",
         )
@@ -144,7 +144,7 @@ class OverflowChip(_BaseChip):
             self._text.click()
         wait_for(
             self._show_more_shown,
-            num_sec=3,
+            timeout=3,
             delay=0.1,
             message="wait for 'show more' button to appear",
         )

--- a/src/widgetastic_patternfly5/components/navigation.py
+++ b/src/widgetastic_patternfly5/components/navigation.py
@@ -41,7 +41,7 @@ class BaseNavigation:
             self.logger.info("Navigation not ready yet")
             wait_for(
                 lambda: self.browser.element(".").get_attribute("data-ouia-safe") == "true",
-                num_sec=10,
+                timeout=10,
             )
         elif not out:
             self.logger.info("Navigation doesn't have 'data-ouia-safe' property")

--- a/testing/components/test_pagination.py
+++ b/testing/components/test_pagination.py
@@ -20,7 +20,7 @@ def _paginator(browser, request, reset_elements_per_page=True):
 
     paginator = TestView(browser).paginator
     browser.click(SIDE_BAR_LOCATOR)  # To jump on specific paginator to avoid flakyness in tests.
-    wait_for(lambda: paginator.is_displayed, num_sec=10)
+    wait_for(lambda: paginator.is_displayed, timeout=10)
     yield paginator
     try:
         paginator.first_page()

--- a/testing/ouia/test_pagination_ouia.py
+++ b/testing/ouia/test_pagination_ouia.py
@@ -15,7 +15,7 @@ def paginator(browser):
         paginator = PaginationOUIA("PaginationTop")
 
     paginator = TestView(browser).paginator
-    wait_for(lambda: paginator.is_displayed, num_sec=10)
+    wait_for(lambda: paginator.is_displayed, timeout=10)
     yield paginator
     try:
         paginator.first_page()


### PR DESCRIPTION
Manual CP of https://github.com/RedHatQE/widgetastic.patternfly5/pull/123 for `legacy-selenium-support` branch which is used by https://github.com/SatelliteQE/airgun

## Summary by Sourcery

Replace deprecated wait_for num_sec parameter with timeout across components and tests.

Bug Fixes:
- Correct a typo in the chip disappearance wait message.

Enhancements:
- Standardize wait_for usage in chip, navigation, and pagination code by using the timeout parameter instead of num_sec.

Tests:
- Update pagination-related tests to use the timeout parameter when waiting for paginator display.