### PR TITLE
[CCXDEV-16481] fix(ocp-advisor-frontend): update CHIP_ROOT selector for PF6 Chip-to-Label migration

### DIFF
--- a/src/widgetastic_patternfly5/components/chip.py
+++ b/src/widgetastic_patternfly5/components/chip.py
@@ -12,7 +12,8 @@ class ChipReadOnlyError(Exception):
 
 
 CHIP_ROOT = (
-    ".//*[contains(@data-ouia-component-type, '/Chip') and not(contains(@class, '-m-overflow')) "
+    ".//*[(contains(@data-ouia-component-type, '/Chip') or contains(@class, '-c-label')) "
+    "and not(contains(@class, '-m-overflow')) "
     "and not(contains(@class, '-c-chip-group') or contains(@class, '-c-label-group'))]"
 )
 CHIP_TEXT = ".//span[contains(@class, '-c-chip__text') or contains(@class, '-c-label__text')]"

--- a/src/widgetastic_patternfly5/components/chip.py
+++ b/src/widgetastic_patternfly5/components/chip.py
@@ -12,7 +12,8 @@ class ChipReadOnlyError(Exception):
 
 
 CHIP_ROOT = (
-    ".//*[(contains(@data-ouia-component-type, '/Chip') or contains(@class, '-c-label')) "
+    ".//*[(contains(@data-ouia-component-type, '/Chip') or "
+    "(contains(@class, '-c-label') and not(contains(@class, '-c-label__')))) "
     "and not(contains(@class, '-m-overflow')) "
     "and not(contains(@class, '-c-chip-group') or contains(@class, '-c-label-group'))]"
 )

--- a/testing/components/test_chip.py
+++ b/testing/components/test_chip.py
@@ -1,4 +1,7 @@
+from urllib.parse import urljoin
+
 import pytest
+from widgetastic.browser import Browser
 from widgetastic.widget import View
 
 from widgetastic_patternfly5 import CategoryChipGroup, ChipGroup
@@ -69,3 +72,31 @@ def test_chipgroup_category(category_chip_group_view):
     # This tests that a category disappears after all chips are removed
     # category_chip_group_view.category_two.remove_all_chips()
     # assert not category_chip_group_view.category_two.is_displayed
+
+
+@pytest.fixture(scope="module")
+def label_overflow_view(browser_context, pf_version):
+    """Navigate to the PF6 Label page to test overflow exclusion on label-based chips."""
+    testing_pages = {"v6": "https://www.patternfly.org", "v5": "https://v5-archive.patternfly.org"}
+    page = browser_context.new_page()
+    page.goto(urljoin(testing_pages[pf_version], "components/label"), wait_until="networkidle")
+    b = Browser(page)
+
+    class TestView(View):
+        ROOT = './/h3[text()="Label group with overflow"]/ancestor::div[@class="ws-example" or contains(@class, "pf-m-gutter")][1]'
+        label_group = ChipGroup()
+
+    yield TestView(b)
+    page.close()
+
+
+@pytest.mark.skip_if_pf5
+def test_overflow_text_excluded_from_label_chips(label_overflow_view):
+    """Overflow button text must not appear in chip list when matching via -c-label class."""
+    group = label_overflow_view.label_group
+    assert group.is_displayed
+    assert group.overflow.is_displayed
+    chips = [chip.text for chip in group.get_chips(show_more=False)]
+    overflow_text = group.overflow.text
+    assert len(chips) > 0
+    assert overflow_text not in chips


### PR DESCRIPTION
## Summary
- Updates `CHIP_ROOT` XPath selector to match both the old OUIA `data-ouia-component-type="/Chip"` attribute and the new `.pf-v6-c-label` CSS class
- Fixes chip detection, clearing, and iteration after [ocp-advisor-frontend#1134](https://github.com/RedHatInsights/ocp-advisor-frontend/pull/1134) migrated FilterChips from PF6/Chip OUIA components to plain PF6 Label components (via `@redhat-cloud-services/frontend-components` 7.0.11 → 7.7.1)

## Problem
The frontend upgrade removed `data-ouia-component-type="PF6/Chip"` from filter chips, replacing them with `.pf-v6-c-label` elements. The `CHIP_ROOT` selector only matched the OUIA attribute, so:
- `clear_all_chips()` silently failed to find/remove active filter chips
- Chip iteration and `remove_all_chips()` returned no results
- Tests relying on chip operations failed in shared browser sessions (CI) where stale filters persisted

## Test plan
- [x] Verified fix locally against ocp-advisor-frontend staging with IQE CCX plugin UI tests
- [ ] widgetastic.patternfly5 unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix detection and removal of filter chips after frontend migration from PF6 Chip OUIA components to PF6 Label components.