### PR TITLE
Test fix

### DIFF
--- a/testing/components/menus/test_dropdown_disabled.py
+++ b/testing/components/menus/test_dropdown_disabled.py
@@ -12,8 +12,9 @@ TESTING_PAGE_COMPONENT = "components/menus/dropdown/react-templates/simple"
 @pytest.fixture
 def view(browser):
     class TestView(View):
+        ROOT = './/div[@id="ws-react-templates-c-dropdown-simple"]'
         dropdown_custom_locator = Dropdown(
-            locator=".//button[contains(@data-ouia-component-type, '/MenuToggle') and contains(@data-ouia-component-id, 'default-1')]/parent::div"
+            locator=".//button[contains(@data-ouia-component-type, '/MenuToggle')][1]/parent::div"
         )
         disable_checkbox = Checkbox(id="simple-example-disabled-toggle")
 

--- a/testing/components/test_alert.py
+++ b/testing/components/test_alert.py
@@ -10,7 +10,7 @@ ALERT_TYPES = ["success", "danger", "warning", "info"]
 @pytest.fixture(params=ALERT_TYPES)
 def alert(browser, request):
     class TestView(View):
-        alert = Alert(locator=f".//div[contains(@class, '-c-alert pf-m-{request.param}')][1]")
+        alert = Alert(locator=f".//div[contains(@class, '-c-alert pf-m-{request.param}') and not(contains(@class, 'ws-nav-announcement'))][1]")
 
     return TestView(browser).alert
 

--- a/testing/components/test_alert.py
+++ b/testing/components/test_alert.py
@@ -10,7 +10,9 @@ ALERT_TYPES = ["success", "danger", "warning", "info"]
 @pytest.fixture(params=ALERT_TYPES)
 def alert(browser, request):
     class TestView(View):
-        alert = Alert(locator=f".//div[contains(@class, '-c-alert pf-m-{request.param}') and not(contains(@class, 'ws-nav-announcement'))][1]")
+        alert = Alert(
+            locator=f".//div[contains(@class, '-c-alert pf-m-{request.param}') and not(contains(@class, 'ws-nav-announcement'))][1]"
+        )
 
     return TestView(browser).alert
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust test locators for alert and disabled dropdown components to exclude announcement alerts and use a more generic dropdown toggle selector.

Tests:
- Update alert component fixture to ignore navigation announcement alerts when selecting alert elements.
- Relax dropdown disabled test locator by scoping to a specific root element and using the first matching menu toggle button.