### PR TITLE
Playwright test dependencies OS install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,34 @@ packages = ["src/widgetastic_patternfly5"]
 source = "vcs"
 raw-options.version_scheme = "calver-by-date"
 
+[tool.hatch.envs.test]
+features = ["dev"]
+
+[tool.hatch.envs.test.scripts]
+# Installs browser binaries and Linux system-level dependencies.
+# Run once after setting up the environment: hatch run test:install-browsers
+install-browsers = [
+  "playwright install chromium firefox",
+  "python scripts/install_playwright_deps.py",
+]
+# Run all tests (headless) – PF version defaults to v6 per conftest
+all  = "pytest -v --headless {args}"
+# PF-version-specific convenience scripts used locally and in CI
+pf5  = "pytest -v --headless --pf-version=v5 {args}"
+pf6  = "pytest -v --headless --pf-version=v6 {args}"
+# Headed mode for local interactive debugging
+debug = "pytest -v --pf-version=v6 {args}"
+
+[tool.hatch.envs.lint]
+dependencies = ["pre-commit"]
+
+[tool.hatch.envs.lint.scripts]
+check = "pre-commit run --all-files"
+
+[tool.pytest.ini_options]
+testpaths = ["testing"]
+timeout = 60
+
 [tool.ruff]
 line-length = 100
 

--- a/scripts/install_playwright_deps.py
+++ b/scripts/install_playwright_deps.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Install Playwright system dependencies in an OS-agnostic way.
+
+Playwright's ``install-deps`` only supports Debian/Ubuntu (apt-get). This
+helper detects the package manager and either delegates to Playwright or
+installs the equivalent RPM packages on Fedora/RHEL.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+# Packages needed for Chromium and Firefox on Fedora/RHEL.
+# Mapped from Playwright's Debian dependency list; see:
+# https://github.com/microsoft/playwright/issues/27890
+FEDORA_PACKAGES = [
+    "nspr",
+    "nss",
+    "dbus-libs",
+    "atk",
+    "at-spi2-atk",
+    "cups-libs",
+    "at-spi2-core",
+    "libX11",
+    "libXcomposite",
+    "libXdamage",
+    "libXext",
+    "libXfixes",
+    "libXrandr",
+    "mesa-libgbm",
+    "libxcb",
+    "libxkbcommon",
+    "pango",
+    "cairo",
+    "alsa-lib",
+    "libdrm",
+    "gtk3",
+]
+
+
+def _run(cmd: list[str]) -> None:
+    print(f"+ {' '.join(cmd)}", flush=True)
+    subprocess.run(
+        cmd, check=True
+    )  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
+
+
+def _install_debian() -> None:
+    print("Detected apt-get; delegating to playwright install-deps.")
+    _run(["playwright", "install-deps"])
+
+
+def _install_fedora() -> None:
+    dnf = shutil.which("dnf") or shutil.which("yum")
+    if dnf is None:
+        raise RuntimeError("Neither dnf nor yum found on PATH")
+
+    print(f"Detected RPM-based system ({dnf}); installing Playwright library dependencies.")
+    cmd = [dnf, "install", "-y", *FEDORA_PACKAGES]
+    if os.geteuid() != 0:
+        if shutil.which("sudo") is None:
+            raise RuntimeError(
+                "Root privileges are required to install system packages, "
+                "but sudo was not found. Re-run as root or install sudo."
+            )
+        cmd = ["sudo", *cmd]
+    _run(cmd)
+
+
+def _skip_macos() -> None:
+    print("macOS detected; Playwright browsers bundle their own dependencies. Nothing to do.")
+
+
+def _unsupported(system: str) -> None:
+    packages = " ".join(FEDORA_PACKAGES)
+    print(
+        f"Unsupported platform for automatic Playwright system deps: {system!r}.\n"
+        "Install browser system libraries manually, then re-run tests.\n\n"
+        "Debian/Ubuntu:\n"
+        "  playwright install-deps\n\n"
+        "Fedora/RHEL:\n"
+        f"  sudo dnf install -y {packages}\n",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def main() -> None:
+    system = platform.system()
+
+    if system == "Darwin":
+        _skip_macos()
+        return
+
+    if system == "Windows":
+        print("Windows detected; Playwright manages browser dependencies. Nothing to do.")
+        return
+
+    if system != "Linux":
+        _unsupported(system)
+
+    if shutil.which("apt-get"):
+        _install_debian()
+        return
+
+    if shutil.which("dnf") or shutil.which("yum"):
+        _install_fedora()
+        return
+
+    _unsupported(system)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as exc:
+        print(f"Command failed with exit code {exc.returncode}: {exc.cmd}", file=sys.stderr)
+        sys.exit(exc.returncode)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary by Sourcery

Introduce Hatch-based Playwright test environments and improve PatternFly widget/browser compatibility and reliability across components and tests.

New Features:
- Add Hatch-managed test and lint environments with reusable pytest scripts for PF5/PF6 runs and headed debugging.
- Provide an OS-aware script to install Playwright system dependencies on Linux distributions beyond Debian/Ubuntu.

Enhancements:
- Rework GitHub Actions test workflow to use Hatch environments, cache them per OS/Python, and drive Playwright installation and pytest via Hatch scripts.
- Increase robustness of menu, dropdown, select, slider, chip, navigation, and radio widgets by using wait-for helpers, more accurate locators, and event-driven interactions compatible with PF5/PF6.
- Tighten Playwright browser context defaults by setting a per-session timeout and adjusting CI matrix naming and pf-version handling for PF5/PF6.
- Update alert and dropdown tests to use PF-version-agnostic locators and section scoping so they work correctly on PatternFly 6.

Build:
- Add Playwright as a development dependency and configure Hatch environments and pytest options in pyproject.toml.

Tests:
- Adjust existing dropdown and alert tests to align with updated locators and PatternFly 6 behaviours, ensuring stability across framework versions.

Chores:
- Replace usage of the external cached_property package with functools.cached_property in relevant components.